### PR TITLE
update aggregatets()

### DIFF
--- a/R/data_handling.R
+++ b/R/data_handling.R
@@ -147,6 +147,7 @@ aggregatets <- function (ts, FUN = "previoustick", on = "minutes", k = 1, weight
     newg <- rawg + (secs - rawg %% secs)
     g    <- as.POSIXct(newg, origin = "1970-01-01", tz = "GMT")
     ts3  <- na.locf(merge(ts, zoo(, g)))[as.POSIXct(g, tz = "GMT")]
+    ts3 <- ts3[!duplicated(index(ts3), fromLast = TRUE)]
     return(ts3) 
   }
 }


### PR DESCRIPTION
Proposed fix for #38: 

Now, the function should only return the last observation at each of the timestamps.
Before this small change, the function could erroneously return more observations than intended due to 'collisions' with aggregation timestamps and timestamps in the data. 

If there were 3 trades on e.g. 09:35:17, and we were to aggregate on every second, 3 observations would be returned for this timestamp.
This should no longer happen.