### PR TITLE
lead-lag now supports non-integer lags.

### DIFF
--- a/R/leadLag.R
+++ b/R/leadLag.R
@@ -72,7 +72,7 @@ leadLag <- function(price1 = NULL, price2 = NULL, lags = NULL, resolution = "sec
   if(!all(class(price1) == class(price2))){
     stop("price1 and price2 must be of same class")
   }
-  
+
   if(parallelize && is.numeric(nCores) && (nCores %% 1) == 0 && nCores < 1){
     parallelize <- FALSE
     warning("nCores is not an integer valued numeric greater than 0. Using non-parallelized code")
@@ -114,6 +114,10 @@ leadLag <- function(price1 = NULL, price2 = NULL, lags = NULL, resolution = "sec
       x <- as.numeric(price1)
       y <- as.numeric(price2)
     }
+  }
+  
+  if(anyNA(x) || anyNA(y) || anyNA(timestampsX) || anyNA(timestampsY)){
+    stop(paste0("lead-lag function does not support NAs in prices or timestamps please take measures to remove these"))
   }
   
   

--- a/man/leadLag.Rd
+++ b/man/leadLag.Rd
@@ -21,7 +21,7 @@ use a column DT to denote the date-time in POSIXct format, and a column PRICE to
 \item{price2}{\code{xts} or \code{data.table} containing prices in levels, in case of data.table,
 use a column DT to denote the date-time in POSIXct format, and a column PRICE to denote the price}
 
-\item{lags}{a numeric denoting which lags (in units of \code{resolution}) should be tested as leading or lagging}
+\item{lags}{a numeric denoting which lags (in integer units of \code{resolution}) should be tested as leading or lagging}
 
 \item{resolution}{the resolution at which the lags is measured. 
 The default is "seconds", use this argument to gain 1000 times resolution by setting it to either "ms", "milliseconds", or "milli-seconds".}

--- a/src/leadLag.cpp
+++ b/src/leadLag.cpp
@@ -12,8 +12,8 @@ arma::vec leadLagCpp(const arma::vec& x, const arma::vec& timestampsX, const arm
                      const bool normalize) {
   
   // Initialize our variables
-  int k, midPointBackup, midPoint, j0, j1;
-  double factorX, factorY, returns;
+  int midPointBackup, midPoint, j0, j1;
+  double k, factorX, factorY, returns;
   const double maxTSY = timestampsY(timestampsY.n_elem - 1);
   const double minTSY = timestampsY[0];
   arma::uword nTests = lags.n_elem;
@@ -97,8 +97,8 @@ arma::vec leadLagCppPAR(const arma::vec& x, const arma::vec& timestampsX, const 
 #ifdef _OPENMP
 omp_set_num_threads(iCores);
   // Initialize our variables
-  int k, midPointBackup, midPoint, j0, j1;
-  double factorX, factorY, returns;
+  int midPointBackup, midPoint, j0, j1;
+  double k, factorX, factorY, returns;
   const double maxTSY = timestampsY(timestampsY.n_elem - 1);
   const double minTSY = timestampsY[0];
   arma::uword nTests = lags.n_elem;


### PR DESCRIPTION
Thought this was already supported, but apparently it wasn't.
