### PR TITLE
fix OpenMP thread save/restore in DriftBurstLoopC

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -37,6 +37,11 @@ DriftBurstLoopCPAR <- function(vPreAveraged, diffedlogprices, vTime, vTesttime, 
 NULL
 
 #' @keywords internal
+getOMPMaxThreads <- function() {
+    .Call(`_highfrequency_getOMPMaxThreads`)
+}
+
+#' @keywords internal
 colCumsum <- function(x) {
     .Call(`_highfrequency_colCumsum`, x)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -120,6 +120,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// getOMPMaxThreads
+int getOMPMaxThreads();
+RcppExport SEXP _highfrequency_getOMPMaxThreads() {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    rcpp_result_gen = Rcpp::wrap(getOMPMaxThreads());
+    return rcpp_result_gen;
+END_RCPP
+}
 // colCumsum
 arma::mat colCumsum(const arma::mat& x);
 RcppExport SEXP _highfrequency_colCumsum(SEXP xSEXP) {
@@ -413,6 +423,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_highfrequency_AutomaticLagSelectionC", (DL_FUNC) &_highfrequency_AutomaticLagSelectionC, 2},
     {"_highfrequency_DriftBurstLoopC", (DL_FUNC) &_highfrequency_DriftBurstLoopC, 8},
     {"_highfrequency_DriftBurstLoopCPAR", (DL_FUNC) &_highfrequency_DriftBurstLoopCPAR, 9},
+    {"_highfrequency_getOMPMaxThreads", (DL_FUNC) &_highfrequency_getOMPMaxThreads, 0},
     {"_highfrequency_colCumsum", (DL_FUNC) &_highfrequency_colCumsum, 1},
     {"_highfrequency_refreshTimeMatching", (DL_FUNC) &_highfrequency_refreshTimeMatching, 2},
     {"_highfrequency_preAveragingReturnsInternal", (DL_FUNC) &_highfrequency_preAveragingReturnsInternal, 2},

--- a/src/driftBursts.cpp
+++ b/src/driftBursts.cpp
@@ -86,11 +86,11 @@ Rcpp::List DriftBurstLoopC(const arma::colvec& vPreAveraged, const arma::colvec&
                            const arma::colvec& vTime, const arma::colvec& vTesttime, 
                            double iMeanBandwidth, double iVarBandwidth, int iPreAverage, int iAcLag){
 #ifdef _OPENMP
-  // From experimentation, setting the number of threads to 1 is much faster than using multi-threaded code. (Why??)
-  // We capture the number of threads that omp is set to, 
+  // We capture the number of threads that omp is set to,
   // set the number of threads using omp_set_num_threads and reset it to the previous value.
-  const int THREADS = omp_get_num_threads(); // Get number of threads to reset later
-  omp_set_num_threads(1); // Set the threading to 1.
+  // Use omp_get_max_threads() since omp_get_num_threads() returns 1 outside a parallel region.
+  const int THREADS = omp_get_max_threads();
+  omp_set_num_threads(1);
 #endif
   // Initialization
   int iT = vTesttime.size();

--- a/src/internals.cpp
+++ b/src/internals.cpp
@@ -1,6 +1,20 @@
 #include <RcppArmadillo.h>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 using namespace arma;
 using namespace Rcpp;
+
+
+//' @keywords internal
+// [[Rcpp::export]]
+int getOMPMaxThreads() {
+#ifdef _OPENMP
+  return omp_get_max_threads();
+#else
+  return NA_INTEGER;
+#endif
+}
 
 
 

--- a/tests/testthat/tests_driftBursts.R
+++ b/tests/testthat/tests_driftBursts.R
@@ -38,7 +38,38 @@ test_that("DBH sim test", {
   expect_equal(lapply(getCriticalValues(DBH, 0.99), round, digits = 4), list(normalizedQuantile = 3.9557, quantile = 4.1752))
   
   expect_output(print(DBH), regexp = NULL)
-  
-  
 
+
+
+})
+
+
+# OpenMP thread state ------------------------------------------------------
+test_that("driftBursts preserves global OpenMP thread limit", {
+  skip_on_cran()
+  #DriftBurstLoopC used to save omp_get_num_threads() (always 1 outside a parallel region) and restore that, pinning the session to 1 thread.
+  ompMax <- highfrequency:::getOMPMaxThreads()
+  skip_if(is.na(ompMax), "OpenMP not available in this build")
+  skip_if(ompMax < 2, "OpenMP max threads is 1, cannot detect regression")
+  set.seed(123)
+  iT <- 1000
+  timestamps <- seq(0, 23400, length.out = iT+1)
+  testtimes  <- seq(60, 23400, 60L)
+  r <- rnorm(iT, mean = 0.02, sd = 1) * sqrt(1/iT)
+  p <- c(0,cumsum(r))
+  dat <- data.table(DT = as.POSIXct(timestamps, tz = 'UTC', origin = as.POSIXct("1970-01-01", tz = 'UTC')), PRICE = exp(p))
+  before <- highfrequency:::getOMPMaxThreads()
+  driftBursts(dat, testtimes, preAverage = 1, ACLag = -1, meanBandwidth = 300L, varianceBandwidth = 1500L, parallelize = FALSE)
+  after <- highfrequency:::getOMPMaxThreads()
+  expect_equal(after, before)
+})
+
+
+test_that("driftBursts.cpp uses omp_get_max_threads, not omp_get_num_threads", {
+  #catch the literal mistake returning even on platforms where _OPENMP isn't built in.
+  srcPath <- file.path("..", "..", "src", "driftBursts.cpp")
+  skip_if_not(file.exists(srcPath), "source not present (installed-only run)")
+  src <- readLines(srcPath)
+  code <- sub("//.*$", "", src)
+  expect_false(any(grepl("omp_get_num_threads\\s*\\(", code)))
 })


### PR DESCRIPTION
https://github.com/jonathancornelissen/highfrequency/blob/eb0e84898ce1c44142726412529bbcf9e296a066/src/driftBursts.cpp#L89

`DriftBurstLoopC` saved `omp_get_num_threads()` before forcing single-threaded execution, but that call returns 1 outside a parallel region, so the "restore" pinned the session to 1 thread for any later OpenMP code. Every benchmark of "parallel" code was running with the global thread limit pinned at 1 by the previous call's restore.

Added tests, then switched the save to `omp_get_max_threads()`.