### PR TITLE
fix rQuar overcount

### DIFF
--- a/R/realizedMeasures.R
+++ b/R/realizedMeasures.R
@@ -2970,7 +2970,7 @@ rQuar <- function(rData, alignBy = NULL, alignPeriod = NULL, makeReturns = FALSE
       rData <- makeReturns(rData)
     }
     q <- as.matrix(rData)
-    N <- nrow(q) + 1
+    N <- nrow(q)
     rQuar <- N/3 * colSums(q^4)
     return(rQuar)
   }

--- a/tests/testthat/tests_realized_measures.R
+++ b/tests/testthat/tests_realized_measures.R
@@ -478,12 +478,13 @@ test_that("rQuar", {
   
   skip_on_cran()
   
-  expect_equal(
-    as.numeric(colMeans(rQuar(sampleOneMinuteData, alignBy ="minutes", alignPeriod = 5, makeReturns = TRUE)[, -"DT"])) * 1000000,
-    c(0.05486143300,0.01361880467)
-  )
-  
-  expect_equal(lapply(rQuar(returnDat), sum), list("PRICE1" = 2.997549025, "PRICE2" = 3.030800189, "PRICE3" = 3.055064757))
+  # closed form: if |r_i| = c for all i, then rQuar = N^2 * c^4 / 3
+  for (N in c(2L, 5L, 100L)) {
+    cc <- 0.01
+    r <- matrix(rep(c(cc, -cc), length.out = N), ncol = 1)
+    expect_equal(as.numeric(rQuar(r)), N^2 * cc^4 / 3)
+  }
+
   expect_equal(lapply(rQuar(returnDat), sum), lapply(rQuar(dat, makeReturns = TRUE), sum))
   
   expect_equal(matrix(rQuar(returnDat), ncol = 3), matrix(as.matrix(rQuar(returnDatDT)[,-1]), ncol = 3))


### PR DESCRIPTION
https://github.com/jonathancornelissen/highfrequency/blob/eb0e84898ce1c44142726412529bbcf9e296a066/R/realizedMeasures.R#L2973

`rQuar` sets `N <- nrow(q) + 1` and then computes the canonical `(N/3) * sum(r^4)` quarticity. The `+1` only makes sense for the sibling estimators (`rMinRVar`, `rMedRVar`, `rTPVar`, `rTPQuar`) which apply a rolling-window reduction first. `rQuar` doesn't, so the `+1` overcounts by one return and biases the result upward by a factor of `(N+1)/N`.

The docstring defines `N` as the return count and cites [Andersen, Dobrev & Schaumburg (2012)](https://www.nber.org/system/files/working_papers/w15533/w15533.pdf). Both match `N = nrow(q)`.

Also updated the tests. The old ones compared `rQuar`'s output to hard-coded numbers that were originally generated under the incorrect formula. The new ones check against the closed form `rQuar = N^2 * c^4 / 3` for constant-magnitude returns: an algebraic identity, not a re-implementation, so it catches the off-by-one independently.