### PR TITLE
fix CHARQ RQ column names

### DIFF
--- a/R/HARmodel.R
+++ b/R/HARmodel.R
@@ -425,9 +425,6 @@ HARmodel <- function(data, periods = c(1, 5, 22), periodsJ = c(1, 5, 22), period
     }
 
     x1 <- cbind(x1, RQmatrix[,1:nperiodsQ] * x1[,1:nperiodsQ])
-    if (is.null(colnames(RQmatrix))) { #special case for 1 aggregation period of realized quarticity. This appends the RQ1 name
-      colnames(x1) <- c(colnames(x1[,1:nperiods]),"RQ1")
-    }
     if(all(colnames(x1) == c(paste0("RV", periods), rep("", nperiodsQ)))){
       colnames(x1) <- c(colnames(x1[,1:nperiods]), paste0("RQ", periodsQ))
     }
@@ -449,9 +446,6 @@ HARmodel <- function(data, periods = c(1, 5, 22), periodsJ = c(1, 5, 22), period
       warning("The realized quarticity is already transformed with sqrt() thus only realized variance is transformed")
     }
     x1 <- cbind(x1, J, RQmatrix[,1:nperiodsQ] * x1[,1:nperiodsQ])
-    if(is.null(colnames(RQmatrix))){ #special case for 1 aggregation period of realized quarticity. This appends the RQ1 name
-      colnames(x1) <- c(colnames(x1[,1:(dim(x1)[2]-1)]), "RQ1")
-    }
     if(all(colnames(x1) == c(paste0("RV", periods), paste0("J", periodsJ), rep("", nperiodsQ)))){
       colnames(x1) <- c(colnames(x1[,1:(nperiods+length(periodsJ))]), paste0("RQ", periodsQ))
     }
@@ -484,9 +478,8 @@ HARmodel <- function(data, periods = c(1, 5, 22), periodsJ = c(1, 5, 22), period
       warning("The realized quarticity is already transformed with sqrt() thus only realized variance and bipower variation is transformed")
     }
     x2 <- cbind(x2, RQmatrix[,1:nperiodsQ] * x2[,1:nperiodsQ])
-
-    if (is.null(colnames(RQmatrix))) { #special case for 1 aggregation period of realized quarticity. This appends the RQ1 name
-      colnames(x2) <- c(colnames(x2[,1:nperiods]), "RQ1")
+    if(all(colnames(x2) == c(paste0("J", periods), rep("", nperiodsQ)))){
+      colnames(x2) <- c(colnames(x2[,1:nperiods]), paste0("RQ", periodsQ))
     }
     x2 <- cbind(x2,rmin)
     model <- estimhar(y = y, x = x2, externalRegressor = externalRegressor)

--- a/tests/testthat/tests_models.R
+++ b/tests/testthat/tests_models.R
@@ -53,6 +53,11 @@ test_that("HARModel",{
                  "RQ1" = -3.581803794e-01 , "RQ5" = -1.695874367e-01  , "RQ22" = -2.373133e-01))
   expect_equal(summary(model)$r.squared, 0.3205499342)
   
+  model <- HARmodel(as.xts(SPYRM[, list(DT, RV5, BPV5, RQ5)]), type = "CHARQ", periodsQ = c(1))
+  expect_equal(model$coefficients,
+               c("(Intercept)" = 4.676123825e-06, "J1" = 9.430126857e-01, "J5" = 3.955722766e-02, "J22" = 4.678487252e-02,
+                 "RQ1" = -3.836656242e-01))
+
   model <- HARmodel(as.xts(SPYRM[, list(DT, RV5, BPV5, RQ5)]), type = "HARQJ", periodsJ = c(1))
   expect_equal(model$coefficients,
                c("(Intercept)" = 3.278421768e-06, "RV1" = 9.738665838e-01, "RV5" = 7.578418611e-03, "RV22" = 2.352647045e-02 , 


### PR DESCRIPTION
`CHARQ` with the default `periodsQ = c(1)` returned a coefficient named `X` instead of `RQ1`. The rename was guarded by `is.null(colnames(RQmatrix))`, which is always FALSE — `HARQ`/`HARQJ` had a working fallback block that masked it; `CHARQ` did not.

Replaced the dead guard with the `all(colnames(x2) == ...)` pattern already used by `HARQ`/`HARQJ`, and dropped the dead block from `HARQ`/`HARQJ`. Added a `CHARQ` regression test.