### PR TITLE
fix summary.HARmodel lag dots

### DIFF
--- a/R/HARmodel.R
+++ b/R/HARmodel.R
@@ -972,8 +972,9 @@ print.HARmodel <- function(x, ...){
 #' @importFrom sandwich NeweyWest
 #' @export
 summary.HARmodel <- function(object, ...){
+  options <- list(...)
   op <- list(lag = 22)
-  op[names(options)] <- list(...)
+  op[names(options)] <- options
   dd <- summary.lm(object)
   dd$coefficients[,"Std. Error"] <- sqrt(diag(NeweyWest(object, lag = op$lag)))
   dd$coefficients[,"t value"] <- dd$coefficients[,"Estimate"] / dd$coefficients[,"Std. Error"]

--- a/tests/testthat/tests_models.R
+++ b/tests/testthat/tests_models.R
@@ -77,6 +77,9 @@ test_that("HARModel",{
   x <- HARmodel(dat, periods = c(1,3), RVest = c("rCov"), type="HAR", inputType = "returns", leverage = c(1,3))
   expect_equal(sum(coef(x)), 0.5175878)
   
+  model <- HARmodel(as.xts(SPYRM[, list(DT, RV5)]))
+  expect_false(identical(summary(model, lag = 22)$coefficients, summary(model, lag = 50)$coefficients))
+
 })
 
 


### PR DESCRIPTION
In `summary.HARmodel`, the dots-handling has a typo:

```r
op <- list(lag = 22)
op[names(options)] <- list(...)
```

`options` here resolves to `base::options` (a function), not a local list. `names(base::options)` is `NULL`, so the assignment is a no-op and the user-supplied `lag` is silently dropped. `op$lag` always stays at 22.

`print.HARmodel` got the same feature and did it correctly (`options <- list(...); opt[names(options)] <- options`). This PR aligns `summary.HARmodel` with that pattern.

Added a regression test asserting `summary(model, lag = 22)` and `summary(model, lag = 50)` produce different coefficient tables.