### PR TITLE
fix HARmodel single-element leverage crash

### DIFF
--- a/R/HARmodel.R
+++ b/R/HARmodel.R
@@ -314,7 +314,7 @@ HARmodel <- function(data, periods = c(1, 5, 22), periodsJ = c(1, 5, 22), period
     # Get the rmins:
     rmintemp <- pmin(e,0)
     # Aggregate everything:
-    rmin <- har_agg(rmintemp, leverage, length(leverage))[(maxp:(n-h)),]
+    rmin <- har_agg(rmintemp, leverage, length(leverage))[(maxp:(n-h)), , drop = FALSE]
     colnames(rmin) <- paste0("Rmin", leverage)
     # Select:
     #rmin <- rmin[(maxp:(n-h)),]

--- a/tests/testthat/tests_models.R
+++ b/tests/testthat/tests_models.R
@@ -77,6 +77,9 @@ test_that("HARModel",{
   x <- HARmodel(dat, periods = c(1,3), RVest = c("rCov"), type="HAR", inputType = "returns", leverage = c(1,3))
   expect_equal(sum(coef(x)), 0.5175878)
   
+  x <- HARmodel(dat, periods = c(1,3), RVest = c("rCov"), type="HAR", inputType = "returns", leverage = c(1))
+  expect_true("Rmin1" %in% names(coef(x)))
+
 })
 
 


### PR DESCRIPTION
`HARmodel(..., leverage = c(<single value>))` errors out:

```
Error in `colnames<-`(`*tmp*`, value = "Rmin1") :
  attempt to set 'colnames' on an object with less than two dimensions
```

In `R/HARmodel.R`, the rmin matrix is indexed without `drop = FALSE`:

```r
rmin <- har_agg(rmintemp, leverage, length(leverage))[(maxp:(n-h)),]
colnames(rmin) <- paste0("Rmin", leverage)
```

When `leverage` has length 1, `[..., ]` drops to a vector and `colnames<-` errors. The `predict.HARmodel` recompute path uses `drop = FALSE`, so the two paths are out of sync. The existing leverage test uses `leverage = c(1, 3)`, which masks the issue.

### Fix

Add `drop = FALSE`.

Added a regression test using `leverage = c(1)`.