### PR TITLE
fix gatherPrices xts branch dropping SYMBOL column

### DIFF
--- a/R/dataHandling.R
+++ b/R/dataHandling.R
@@ -3089,12 +3089,10 @@ spreadPrices <- function(data){
 #' @export
 gatherPrices <- function(data){
   
-  inputWasXts <- FALSE
   if (!is.data.table(data)) {
     if (is.xts(data)) {
       data <- as.data.table(data)
       data <- setnames(data , old = "index", new = "DT")
-      inputWasXts <- TRUE
     } else {
       stop("Input has to be data.table or xts.")
     }
@@ -3105,13 +3103,6 @@ gatherPrices <- function(data){
   }
   data <- melt(data, 1, na.rm = TRUE, variable.factor = FALSE)
   setnames(data, old = c("variable", "value"), new = c("SYMBOL", "PRICE"))
-  
-  if (inputWasXts) {
-    data <- as.xts(data)
-    storage.mode(data) <- 'numeric'
-    return(data)
-  } else {
-    setkeyv(data, c("DT", "SYMBOL"))
-    return(data[])
-  }
+  setkeyv(data, c("DT", "SYMBOL"))
+  return(data[])
 }

--- a/tests/testthat/tests_data_handling.R
+++ b/tests/testthat/tests_data_handling.R
@@ -487,6 +487,11 @@ test_that("gatherPrices and spreadPrices back and forth", {
   expect_equal(dat1, gatherPrices(dat))
   expect_equal(spreadPrices(gatherPrices(dat)), dat)
   
+  xt <- xts(dat1[SYMBOL == "XYZ", list(PRICE)], order.by = dat1[SYMBOL == "XYZ", DT])
+  out <- gatherPrices(xt)
+  expect_true(is.data.table(out))
+  expect_equal(sort(colnames(out)), c("DT", "PRICE", "SYMBOL"))
+
 })
 
 # aggregateTrades, aggregatePrice, and aggregateQuotes multisymbol --------


### PR DESCRIPTION
When passing an xts to `gatherPrices`, the SYMBOL column is silently dropped, returning a single-column xts with just PRICE.

This is because the xts return branch does `storage.mode(data) <- 'numeric'` after `as.xts`, which strips the character SYMBOL column.

Fix: drop the xts return branch. xts input is still accepted, but the output is always a `data.table`.